### PR TITLE
update to released 0.24 version of pyo3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,7 @@ members = ["azure_data_cosmos_engine", "cosmoscx", "python"]
 
 [workspace.dependencies]
 azure_data_cosmos_engine = { path = "azure_data_cosmos_engine" }
-# TODO: We depend on features in an unreleased version of PyO3, but the 0.24 release should be coming soon 🤞, see https://github.com/PyO3/pyo3/issues/4905
-pyo3 = { git = "https://github.com/PyO3/pyo3.git", branch = "main" }
+pyo3 = "0.24.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 tracing = "0.1.40"


### PR DESCRIPTION
We were depending on a not-yet-released version of pyo3 to get a specific feature around deriving `FromPyObject`. That version has now been released, so we can move off from referencing the git repo!