### PR TITLE
trigger the pipelines to run on commits, and nightly, to maintain CodeQL checks

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,9 +1,24 @@
-trigger: none
+trigger:
+  - main
+  - feature/*
+  - hotfix/*
+  - release/*
+
+# Run the build nightly to ensure our CodeQL and other compliance checks run regularly.
+schedules:
+  # https://crontab.guru/#42_7_*_*_*
+  # 07:42 UTC => 00:42 PST / 23:42 PDT
+  - cron: 42 7 * * *
+    displayName: Nightly Check build
 
 extends:
   template: /script/pipelines/pipeline-template.yml
   parameters:
-    IsReleaseBuild: true
+    ${{ if in(variables['Build.Reason'], 'Manual', '') }}:
+      IsReleaseBuild: true
+    ${{ else }}:
+      IsReleaseBuild: false
+
     UseMicrosoftToolchain: true
     LinuxPool:
       name: SDK-RustClientEngine

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -10,6 +10,9 @@ schedules:
   # 07:42 UTC => 00:42 PST / 23:42 PDT
   - cron: 42 7 * * *
     displayName: Nightly Check build
+    branches:
+      include:
+        - main
 
 extends:
   template: /script/pipelines/pipeline-template.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,15 @@
-trigger: none
+trigger:
+  - main
+  - feature/*
+  - hotfix/*
+  - release/*
+
+# Run the build nightly to ensure our CodeQL and other compliance checks run regularly.
+schedules:
+  # https://crontab.guru/#42_7_*_*_*
+  # 07:42 UTC => 00:42 PST / 23:42 PDT
+  - cron: 42 7 * * *
+    displayName: Nightly Check build
 
 pr:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,9 @@ schedules:
   # 07:42 UTC => 00:42 PST / 23:42 PDT
   - cron: 42 7 * * *
     displayName: Nightly Check build
+    branches:
+      include:
+        - main
 
 pr:
   branches:


### PR DESCRIPTION
This PR adds triggers to our various Azure Pipeline builds to run on each commit to a main branch, and on a nightly schedule (just in case the repo goes quiet). This is necessary in order to maintain our mandatory security checks.