### PR TITLE
refactor strategies for better readability

### DIFF
--- a/azure_data_cosmos_engine/src/lib.rs
+++ b/azure_data_cosmos_engine/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Warnings are errors when building on CI.
-#![cfg_attr(not(debug_assertions), deny(warnings))]
-
 macro_rules! make_cstr {
     ($s: expr) => {
         unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(concat!($s, "\0").as_bytes()) }

--- a/azure_data_cosmos_engine/src/query/producer/mod.rs
+++ b/azure_data_cosmos_engine/src/query/producer/mod.rs
@@ -139,7 +139,10 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
-    use crate::query::{PartitionKeyRange, QueryResult};
+    use crate::{
+        query::{PartitionKeyRange, QueryResult},
+        ErrorKind,
+    };
 
     use super::*;
 

--- a/azure_data_cosmos_engine/src/query/producer/mod.rs
+++ b/azure_data_cosmos_engine/src/query/producer/mod.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::{
-    query::{node::PipelineNodeResult, DataRequest, PartitionKeyRange, QueryResult, SortOrder},
-    ErrorKind,
+use crate::query::{
+    node::PipelineNodeResult, DataRequest, PartitionKeyRange, QueryResult, SortOrder,
 };
 
 mod non_streaming;

--- a/azure_data_cosmos_engine/src/query/producer/mod.rs
+++ b/azure_data_cosmos_engine/src/query/producer/mod.rs
@@ -1,293 +1,45 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::{
-    cmp::Ordering,
-    collections::{BinaryHeap, VecDeque},
-};
-
 use crate::{
-    query::{
-        node::PipelineNodeResult,
-        producer::{
-            sorting::{SortableResult, Sorting},
-            state::PartitionState,
-        },
-        DataRequest, PartitionKeyRange, QueryResult, SortOrder,
-    },
+    query::{node::PipelineNodeResult, DataRequest, PartitionKeyRange, QueryResult, SortOrder},
     ErrorKind,
 };
 
+mod non_streaming;
 mod sorting;
 mod state;
+mod streaming;
+mod unordered;
 
-/// Indicates the way in which multiple partition results should be merged.
-enum ProducerStrategy {
-    /// Results are not re-ordered by the query and should be ordered by the partition key range minimum.
-    Unordered {
-        current_partition_index: usize,
-        current_pkrange_id: Option<String>,
-        items: VecDeque<QueryResult>,
-    },
-
-    /// Results should be merged by comparing the sort order of the `ORDER BY` items. Results can be streamed, because each partition will provide data in a global order.
-    Streaming {
-        sorting: Sorting,
-        buffers: Vec<(String, VecDeque<QueryResult>)>, // (partition key range ID, buffer)
-    },
-    /// Results should be merged by comparing the sort order of the `ORDER BY` items. Results cannot be streamed, because each partition will provide data in a local order.
-    NonStreaming {
-        sorting: Sorting,
-        items: BinaryHeap<SortableResult>,
-    },
-}
-
-impl ProducerStrategy {
-    pub fn requests(&mut self, partitions: &[PartitionState]) -> Option<Vec<DataRequest>> {
-        // Fetches the next set of requests to be made to get additional data.
-        match self {
-            ProducerStrategy::Unordered {
-                ref mut current_partition_index,
-                ref mut current_pkrange_id,
-                ..
-            } => {
-                // In the unordered strategy, we simply return the first partition key range's request.
-                // Once that partition is exhausted, we remove it from the list and return the next one.
-                let mut requests = Vec::new();
-                while requests.is_empty() {
-                    // If there are no more partitions, return None.
-                    let partition = partitions.get(*current_partition_index)?;
-                    match partition.request() {
-                        Some(request) => {
-                            tracing::trace!(pkrange_id = ?partition.pkrange.id, "requesting data for partition");
-                            requests.push(request);
-                        }
-                        None => {
-                            tracing::trace!(pkrange_id = ?partition.pkrange.id, "partition exhausted, removing from list");
-                            *current_partition_index += 1;
-                            *current_pkrange_id = partitions
-                                .get(*current_partition_index)
-                                .map(|p| p.pkrange.id.clone());
-                        }
-                    }
-                }
-                Some(requests)
-            }
-
-            // In the ordered strategies, we return a request for each partition.
-            ProducerStrategy::Streaming { .. } | ProducerStrategy::NonStreaming { .. } => {
-                let requests = partitions
-                    .iter()
-                    .filter_map(|partition| partition.request())
-                    .collect::<Vec<_>>();
-                // If there are no requests, we return None.
-                if requests.is_empty() {
-                    None
-                } else {
-                    Some(requests)
-                }
-            }
-        }
-    }
-
-    pub fn provide_data(
-        &mut self,
-        partition: &PartitionState,
-        data: Vec<QueryResult>,
-    ) -> crate::Result<()> {
-        // Provides data for the given partition key range.
-        match self {
-            ProducerStrategy::Unordered {
-                current_pkrange_id,
-                items,
-                ..
-            } => {
-                match current_pkrange_id {
-                    Some(id) => {
-                        if *id != partition.pkrange.id {
-                            // The caller provided data for a different partition key range ID before draining the current items queue.
-                            return Err(ErrorKind::InternalError.with_message(format!(
-                                    "provided data for partition key range ID: {}, but current partition is: {}",
-                                    partition.pkrange.id, id
-                                )));
-                        }
-                    }
-                    None => {
-                        return Err(ErrorKind::InternalError.with_message(format!(
-                            "provided data for partition key range ID: {}, but all partitions are exhausted",
-                            partition.pkrange.id
-                        )));
-                    }
-                }
-
-                // Add the data to the items queue. There's no ordering to worry about, so we just append the items.
-                items.extend(data);
-            }
-            ProducerStrategy::Streaming { buffers, .. } => {
-                // Find the buffer for the given partition key range ID.
-                let (pkrange_id, buffer) = buffers.get_mut(partition.index).ok_or_else(|| {
-                    ErrorKind::InternalError.with_message(format!(
-                        "missing buffer for partition key range ID: {}",
-                        partition.pkrange.id
-                    ))
-                })?;
-                debug_assert_eq!(
-                    pkrange_id, &partition.pkrange.id,
-                    "buffer ID should match partition key range ID",
-                );
-                // We assume the data is coming from the server pre-sorted, so we can just extend the buffer with the data.
-                buffer.extend(data);
-            }
-            ProducerStrategy::NonStreaming { sorting, items } => {
-                // Insert the items into the heap as we go, which will keep them sorted
-                for item in data {
-                    // We need to sort the items by the order by items, so we create a SortableResult.
-                    items.push(SortableResult::new(sorting.clone(), item));
-                }
-            }
-        }
-        Ok(())
-    }
-
-    pub fn produce_item(
-        &mut self,
-        partitions: &[PartitionState],
-    ) -> crate::Result<PipelineNodeResult> {
-        // Gets the next item from the merge strategy.
-        match self {
-            ProducerStrategy::Unordered {
-                items,
-                current_partition_index,
-                ..
-            } => {
-                let value = items.pop_front();
-                let terminated = items.is_empty()
-                    && (*current_partition_index == partitions.len() - 1)
-                    && partitions[*current_partition_index].done();
-                Ok(PipelineNodeResult { value, terminated })
-            }
-            ProducerStrategy::Streaming { sorting, buffers } => {
-                // Scan through each partition to find the next item to produce.
-                // We do the scan first with an immutable borrow of the buffers, and then end up with the index of the partition that has the next item to produce.
-                // Then we can borrow the buffer mutably after the loop to pop the item out of it.
-                let mut current_match = None;
-                for (i, partition) in partitions.iter().enumerate() {
-                    let (pkrange_id, buffer) = buffers.get(i).ok_or_else(|| {
-                        ErrorKind::InternalError.with_message(format!(
-                            "missing buffer for partition key range ID: {}",
-                            partition.pkrange.id
-                        ))
-                    })?;
-                    debug_assert_eq!(pkrange_id, &partition.pkrange.id); // This should always be true, as the lists are initialized together.
-
-                    if !partition.started() {
-                        // If any partition hasn't started, we have to stop producing items.
-                        // A Partition is considered "started" when we've received at least one `provide_data` call referencing it.
-                        // For a streaming order by, we can't stream ANY results until we've received at least one set of results from each partition.
-                        // The missing partitions may contain values that sort BEFORE items in the partitions we've received.
-                        //
-                        // SDKs could optimize how they call the engine to avoid this scenario (by always making requests first, for example),
-                        // but we can't assume that will always be the case.
-                        tracing::debug!(pkrange_id = ?partition.pkrange.id, "partition not started, stopping item production");
-                        return Ok(PipelineNodeResult::NO_RESULT);
-                    }
-
-                    if partition.done() && buffer.is_empty() {
-                        // If the partition is done and the buffer is empty, we can skip it.
-                        // In fact, we NEED to skip it because we know it won't produce any more items and if we leave it in the set of partitions we consider,
-                        // we might end up trying to query it for more data.
-                        tracing::debug!(pkrange_id = ?partition.pkrange.id, "partition done and buffer empty, skipping");
-                        continue;
-                    }
-
-                    match current_match {
-                        None => {
-                            // If we haven't found a match yet, we set the current match to this partition so that we always pick a partition.
-                            current_match = Some((i, buffer.front()));
-                        }
-                        Some((current_index, current_item)) => {
-                            match sorting.compare(
-                                current_item.map(|r| r.order_by_items.as_slice()),
-                                buffer.front().map(|r| r.order_by_items.as_slice()),
-                            )? {
-                                Ordering::Greater => {
-                                    // The current item sorts higher than the new item, so we keep the current match.
-                                    continue;
-                                }
-                                Ordering::Less => {
-                                    // The new item sorts higher than the current item, so we update the current match to this partition.
-                                    // Note: This might be because the partition's buffer is currently empty.
-                                    // That can result in the selected partition being one with an empty buffer.
-                                    // This is intentional, see below where we return the item.
-                                    current_match = Some((i, buffer.front()));
-                                }
-                                Ordering::Equal => {
-                                    // Compare the index of the partitions to ensure we always return the first partition with the same item.
-                                    if i < current_index {
-                                        // The new item is equal to the current item, but the partition index is lower,
-                                        // so we update the current match to this partition.
-                                        current_match = Some((i, buffer.front()));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                if let Some((i, _)) = current_match {
-                    // We found a match, pop the item out of the buffer and return it.
-                    debug_assert_eq!(
-                        buffers[i].0, partitions[i].pkrange.id,
-                        "buffer ID should match partition key range ID",
-                    );
-                    // If the buffer is empty, this may return `None`. That's by design!
-                    // It means the partition has an empty buffer, and we may need to fetch more data for it.
-                    // If it was fully exhausted, the check for `done() && buffer.is_empty()` would have excluded it.
-                    // Instead, we have an empty buffer AND the possibility for more data from this partition.
-                    // That means we WANT to return `None` here. We need to check this partition for more data before we can yield an item.
-                    let value = buffers[i].1.pop_front();
-                    let terminated = value.is_none() && partitions.iter().all(|p| p.done());
-                    Ok(PipelineNodeResult { value, terminated })
-                } else {
-                    // No match found, meaning all partitions are either exhausted or waiting for data.
-                    let terminated = partitions.iter().all(|p| p.done());
-                    Ok(PipelineNodeResult {
-                        value: None,
-                        terminated,
-                    })
-                }
-            }
-            ProducerStrategy::NonStreaming { items, .. } => {
-                // We can only produce items when all partitions are done.
-                if partitions.iter().any(|p| !p.done()) {
-                    // If any partition is not done, we cannot produce items yet.
-                    tracing::debug!("not all partitions are done, cannot produce items");
-                    return Ok(PipelineNodeResult::NO_RESULT);
-                }
-
-                // We can just pop the next item from the heap, as it is already sorted.
-                let value = items.pop().map(|r| r.into());
-                Ok(PipelineNodeResult {
-                    value,
-                    terminated: items.is_empty(),
-                })
-            }
-        }
-    }
-}
+use non_streaming::NonStreamingStrategy;
+use state::PartitionState;
+use streaming::StreamingStrategy;
+use unordered::UnorderedStrategy;
 
 /// An item producer handles merging results from several partitions into a single stream of results.
 ///
-/// The single-partition result streams are merged according to a [`ProducerStrategy`] selected when the producer is initialized.
+/// The single-partition result streams are merged according to the variant of the producer selected when the producer is initialized.
 /// The producer is only responsible for handling ordering the results, other query operations like aggregations or offset/limit
 /// are handled by the pipeline that runs after a specific item has been produced.
 /// Ordering can't really be done by the pipeline though, since it may require buffering results from some or all partitions.
 /// So, before the pipeline runs, the producer is responsible for actually organizing the initial set of results in the correct order.
-pub struct ItemProducer {
-    strategy: ProducerStrategy,
-    partitions: Vec<PartitionState>,
+// --
+// This uses a common Rust pattern for internal-only "dynamic dispatch" called "enum dispatch".
+// True dynamic dispatch, using `dyn` has an increased runtime cost and hides information from the optimizer leading to even more performance loss.
+// Since this is an internal API, we can use an enum to select the strategy at runtime and delegate methods to the appropriate concrete strategy type.
+// This dispatch should be no worse than a virtual function call, and is often quite a lot better.
+// See https://crates.io/crates/enum_dispatch for more on this pattern (we're not using that crate, but we're doing what it does manually).
+pub enum ItemProducer {
+    /// Results are not re-ordered by the query and should be ordered by the partition key range minimum.
+    Unordered(UnorderedStrategy),
+    /// Results should be merged by comparing the sort order of the `ORDER BY` items. Results can be streamed, because each partition will provide data in a global order.
+    Streaming(StreamingStrategy),
+    /// Results should be merged by comparing the sort order of the `ORDER BY` items. Results cannot be streamed, because each partition will provide data in a local order.
+    NonStreaming(NonStreamingStrategy),
 }
 
-fn create_partition_state(
+pub fn create_partition_state(
     pkranges: impl IntoIterator<Item = PartitionKeyRange>,
 ) -> Vec<PartitionState> {
     let mut partitions = pkranges
@@ -307,15 +59,7 @@ impl ItemProducer {
     ///
     /// Use this for queries that don't require global ordering across partitions.
     pub fn unordered(pkranges: impl IntoIterator<Item = PartitionKeyRange>) -> Self {
-        let partitions = create_partition_state(pkranges);
-        Self {
-            strategy: ProducerStrategy::Unordered {
-                current_partition_index: 0,
-                current_pkrange_id: partitions.first().map(|p| p.pkrange.id.clone()),
-                items: VecDeque::new(),
-            },
-            partitions,
-        }
+        Self::Unordered(UnorderedStrategy::new(pkranges))
     }
 
     /// Creates a producer for ORDER BY queries where each partition returns globally sorted results.
@@ -332,17 +76,7 @@ impl ItemProducer {
         pkranges: impl IntoIterator<Item = PartitionKeyRange>,
         sorting: Vec<SortOrder>,
     ) -> Self {
-        let partitions = create_partition_state(pkranges);
-        Self {
-            strategy: ProducerStrategy::Streaming {
-                sorting: Sorting::new(sorting),
-                buffers: partitions
-                    .iter()
-                    .map(|p| (p.pkrange.id.clone(), VecDeque::new()))
-                    .collect(),
-            },
-            partitions,
-        }
+        Self::Streaming(StreamingStrategy::new(pkranges, sorting))
     }
 
     /// Creates a producer for ORDER BY queries where partitions return locally sorted results.
@@ -360,20 +94,18 @@ impl ItemProducer {
         pkranges: impl IntoIterator<Item = PartitionKeyRange>,
         sorting: Vec<SortOrder>,
     ) -> Self {
-        let partitions = create_partition_state(pkranges);
-        Self {
-            strategy: ProducerStrategy::NonStreaming {
-                sorting: Sorting::new(sorting),
-                items: BinaryHeap::new(),
-            },
-            partitions,
-        }
+        Self::NonStreaming(NonStreamingStrategy::new(pkranges, sorting))
     }
 
     /// Gets the [`DataRequest`]s that must be performed in order to add additional data to the partition buffers.
     pub fn data_requests(&mut self) -> Vec<DataRequest> {
         // The default value for Vec is an empty vec, which doesn't allocate until items are added.
-        self.strategy.requests(&self.partitions).unwrap_or_default()
+        match self {
+            ItemProducer::Unordered(s) => s.requests(),
+            ItemProducer::Streaming(s) => s.requests(),
+            ItemProducer::NonStreaming(s) => s.requests(),
+        }
+        .unwrap_or_default()
     }
 
     /// Provides additional data for the given partition.
@@ -383,30 +115,27 @@ impl ItemProducer {
         data: Vec<QueryResult>,
         continuation: Option<String>,
     ) -> crate::Result<()> {
-        let partition = self
-            .partitions
-            .iter_mut()
-            .find(|p| p.pkrange.id == pkrange_id)
-            .ok_or_else(|| {
-                ErrorKind::UnknownPartitionKeyRange
-                    .with_message(format!("unknown partition key range ID: {pkrange_id}"))
-            })?;
-        self.strategy.provide_data(partition, data)?;
-        partition.update_state(continuation);
-
-        Ok(())
+        match self {
+            ItemProducer::Unordered(s) => s.provide_data(pkrange_id, data, continuation),
+            ItemProducer::Streaming(s) => s.provide_data(pkrange_id, data, continuation),
+            ItemProducer::NonStreaming(s) => s.provide_data(pkrange_id, data, continuation),
+        }
     }
 
     /// Requests the next item from the cross-partition result stream.
     #[tracing::instrument(level = "trace", skip(self))]
     pub fn produce_item(&mut self) -> crate::Result<PipelineNodeResult> {
-        self.strategy.produce_item(&self.partitions)
+        match self {
+            ItemProducer::Unordered(s) => s.produce_item(),
+            ItemProducer::Streaming(s) => s.produce_item(),
+            ItemProducer::NonStreaming(s) => s.produce_item(),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, VecDeque};
 
     use serde::{Deserialize, Serialize};
     use serde_json::json;

--- a/azure_data_cosmos_engine/src/query/producer/non_streaming.rs
+++ b/azure_data_cosmos_engine/src/query/producer/non_streaming.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::BinaryHeap;
+
+use crate::{
+    query::{node::PipelineNodeResult, DataRequest, PartitionKeyRange, QueryResult, SortOrder},
+    ErrorKind,
+};
+
+use super::{
+    create_partition_state,
+    sorting::{SortableResult, Sorting},
+    state::PartitionState,
+};
+
+pub struct NonStreamingStrategy {
+    pub partitions: Vec<PartitionState>,
+    pub sorting: Sorting,
+    pub items: BinaryHeap<SortableResult>,
+}
+
+impl NonStreamingStrategy {
+    pub fn new(
+        pkranges: impl IntoIterator<Item = PartitionKeyRange>,
+        sorting: Vec<SortOrder>,
+    ) -> Self {
+        let partitions = create_partition_state(pkranges);
+        Self {
+            partitions,
+            sorting: Sorting::new(sorting),
+            items: BinaryHeap::new(),
+        }
+    }
+
+    pub fn requests(&mut self) -> Option<Vec<DataRequest>> {
+        let requests = self
+            .partitions
+            .iter()
+            .filter_map(|partition| partition.request())
+            .collect::<Vec<_>>();
+        // If there are no requests, we return None.
+        if requests.is_empty() {
+            None
+        } else {
+            Some(requests)
+        }
+    }
+
+    pub fn provide_data(
+        &mut self,
+        pkrange_id: &str,
+        data: Vec<QueryResult>,
+        continuation: Option<String>,
+    ) -> crate::Result<()> {
+        // Insert the items into the heap as we go, which will keep them sorted
+        for item in data {
+            // We need to sort the items by the order by items, so we create a SortableResult.
+            self.items
+                .push(SortableResult::new(self.sorting.clone(), item));
+        }
+
+        // Update the partition state with the continuation token
+        let partition = self
+            .partitions
+            .iter_mut()
+            .find(|p| p.pkrange.id == pkrange_id)
+            .ok_or_else(|| {
+                ErrorKind::UnknownPartitionKeyRange
+                    .with_message(format!("unknown partition key range ID: {pkrange_id}"))
+            })?;
+        partition.update_state(continuation);
+
+        Ok(())
+    }
+
+    pub fn produce_item(&mut self) -> crate::Result<PipelineNodeResult> {
+        // We can only produce items when all partitions are done.
+        if self.partitions.iter().any(|p| !p.done()) {
+            // If any partition is not done, we cannot produce items yet.
+            tracing::debug!("not all partitions are done, cannot produce items");
+            return Ok(PipelineNodeResult::NO_RESULT);
+        }
+
+        // We can just pop the next item from the heap, since it's already sorted.
+        let value = self.items.pop().map(|r| r.into());
+        Ok(PipelineNodeResult {
+            value,
+            terminated: self.items.is_empty(),
+        })
+    }
+}

--- a/azure_data_cosmos_engine/src/query/producer/streaming.rs
+++ b/azure_data_cosmos_engine/src/query/producer/streaming.rs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::{cmp::Ordering, collections::VecDeque};
+
+use crate::{
+    query::{node::PipelineNodeResult, DataRequest, PartitionKeyRange, QueryResult, SortOrder},
+    ErrorKind,
+};
+
+use super::{create_partition_state, sorting::Sorting, state::PartitionState};
+
+pub struct StreamingStrategy {
+    pub partitions: Vec<PartitionState>,
+    pub sorting: Sorting,
+    pub buffers: Vec<(String, VecDeque<QueryResult>)>,
+}
+
+impl StreamingStrategy {
+    pub fn new(
+        pkranges: impl IntoIterator<Item = PartitionKeyRange>,
+        sorting: Vec<SortOrder>,
+    ) -> Self {
+        let partitions = create_partition_state(pkranges);
+        let buffers = partitions
+            .iter()
+            .map(|p| (p.pkrange.id.clone(), VecDeque::new()))
+            .collect();
+        Self {
+            partitions,
+            sorting: Sorting::new(sorting),
+            buffers,
+        }
+    }
+
+    pub fn requests(&mut self) -> Option<Vec<DataRequest>> {
+        let requests = self
+            .partitions
+            .iter()
+            .filter_map(|partition| partition.request())
+            .collect::<Vec<_>>();
+        // If there are no requests, we return None.
+        if requests.is_empty() {
+            None
+        } else {
+            Some(requests)
+        }
+    }
+
+    pub fn provide_data(
+        &mut self,
+        pkrange_id: &str,
+        data: Vec<QueryResult>,
+        continuation: Option<String>,
+    ) -> crate::Result<()> {
+        let partition_index = self
+            .partitions
+            .iter()
+            .position(|p| p.pkrange.id == pkrange_id)
+            .ok_or_else(|| {
+                ErrorKind::UnknownPartitionKeyRange
+                    .with_message(format!("unknown partition key range ID: {pkrange_id}"))
+            })?;
+        let (pkrange_id, buffer) = self.buffers.get_mut(partition_index).ok_or_else(|| {
+            ErrorKind::InternalError.with_message(format!(
+                "missing buffer for partition index: {}",
+                partition_index
+            ))
+        })?;
+        debug_assert_eq!(
+            pkrange_id, &self.partitions[partition_index].pkrange.id,
+            "buffer ID should match partition key range ID",
+        );
+
+        // We assume the data is coming from the server pre-sorted, so we can just extend the buffer with the data.
+        buffer.extend(data);
+
+        self.partitions[partition_index].update_state(continuation);
+
+        Ok(())
+    }
+
+    pub fn produce_item(&mut self) -> crate::Result<PipelineNodeResult> {
+        // Scan through each partition to find the next item to produce.
+        // We do the scan first with an immutable borrow of the buffers, and then end up with the index of the partition that has the next item to produce.
+        // Then we can borrow the buffer mutably after the loop to pop the item out of it.
+        let mut current_match = None;
+        for (i, partition) in self.partitions.iter().enumerate() {
+            let (pkrange_id, buffer) = self.buffers.get(i).ok_or_else(|| {
+                ErrorKind::InternalError.with_message(format!(
+                    "missing buffer for partition key range ID: {}",
+                    partition.pkrange.id
+                ))
+            })?;
+            debug_assert_eq!(pkrange_id, &partition.pkrange.id); // This should always be true, as the lists are initialized together.
+
+            if !partition.started() {
+                // If any partition hasn't started, we have to stop producing items.
+                // A Partition is considered "started" when we've received at least one `provide_data` call referencing it.
+                // For a streaming order by, we can't stream ANY results until we've received at least one set of results from each partition.
+                // The missing partitions may contain values that sort BEFORE items in the partitions we've received.
+                //
+                // SDKs could optimize how they call the engine to avoid this scenario (by always making requests first, for example),
+                // but we can't assume that will always be the case.
+                tracing::debug!(pkrange_id = ?partition.pkrange.id, "partition not started, stopping item production");
+                return Ok(PipelineNodeResult::NO_RESULT);
+            }
+
+            if partition.done() && buffer.is_empty() {
+                // If the partition is done and the buffer is empty, we can skip it.
+                // In fact, we NEED to skip it because we know it won't produce any more items and if we leave it in the set of partitions we consider,
+                // we might end up trying to query it for more data.
+                tracing::debug!(pkrange_id = ?partition.pkrange.id, "partition done and buffer empty, skipping");
+                continue;
+            }
+
+            match current_match {
+                None => {
+                    // If we haven't found a match yet, we set the current match to this partition so that we always pick a partition.
+                    current_match = Some((i, buffer.front()));
+                }
+                Some((current_index, current_item)) => {
+                    match self.sorting.compare(
+                        current_item.map(|r| r.order_by_items.as_slice()),
+                        buffer.front().map(|r| r.order_by_items.as_slice()),
+                    )? {
+                        Ordering::Greater => {
+                            // The current item sorts higher than the new item, so we keep the current match.
+                            continue;
+                        }
+                        Ordering::Less => {
+                            // The new item sorts higher than the current item, so we update the current match to this partition.
+                            // Note: This might be because the partition's buffer is currently empty.
+                            // That can result in the selected partition being one with an empty buffer.
+                            // This is intentional, see below where we return the item.
+                            current_match = Some((i, buffer.front()));
+                        }
+                        Ordering::Equal => {
+                            // Compare the index of the partitions to ensure we always return the first partition with the same item.
+                            if i < current_index {
+                                // The new item is equal to the current item, but the partition index is lower,
+                                // so we update the current match to this partition.
+                                current_match = Some((i, buffer.front()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if let Some((i, _)) = current_match {
+            // We found a match, pop the item out of the buffer and return it.
+            debug_assert_eq!(
+                self.buffers[i].0, self.partitions[i].pkrange.id,
+                "buffer ID should match partition key range ID",
+            );
+            // If the buffer is empty, this may return `None`. That's by design!
+            // It means the partition has an empty buffer, and we may need to fetch more data for it.
+            // If it was fully exhausted, the check for `done() && buffer.is_empty()` would have excluded it.
+            // Instead, we have an empty buffer AND the possibility for more data from this partition.
+            // That means we WANT to return `None` here. We need to check this partition for more data before we can yield an item.
+            let value = self.buffers[i].1.pop_front();
+            let terminated = value.is_none() && self.partitions.iter().all(|p| p.done());
+            Ok(PipelineNodeResult { value, terminated })
+        } else {
+            // No match found, meaning all partitions are either exhausted or waiting for data.
+            let terminated = self.partitions.iter().all(|p| p.done());
+            Ok(PipelineNodeResult {
+                value: None,
+                terminated,
+            })
+        }
+    }
+}

--- a/azure_data_cosmos_engine/src/query/producer/unordered.rs
+++ b/azure_data_cosmos_engine/src/query/producer/unordered.rs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::VecDeque;
+
+use crate::{
+    query::{node::PipelineNodeResult, DataRequest, PartitionKeyRange, QueryResult},
+    ErrorKind,
+};
+
+use super::{create_partition_state, state::PartitionState};
+
+pub struct UnorderedStrategy {
+    pub partitions: Vec<PartitionState>,
+    pub current_partition_index: usize,
+    pub current_pkrange_id: Option<String>,
+    pub items: VecDeque<QueryResult>,
+}
+
+impl UnorderedStrategy {
+    pub fn new(pkranges: impl IntoIterator<Item = PartitionKeyRange>) -> Self {
+        let partitions = create_partition_state(pkranges);
+        Self {
+            current_partition_index: 0,
+            current_pkrange_id: partitions.first().map(|p| p.pkrange.id.clone()),
+            items: VecDeque::new(),
+            partitions,
+        }
+    }
+
+    pub fn requests(&mut self) -> Option<Vec<DataRequest>> {
+        // In the unordered strategy, we simply return the first partition key range's request.
+        // Once that partition is exhausted, we remove it from the list and return the next one.
+        let mut requests = Vec::new();
+        while requests.is_empty() {
+            // If there are no more partitions, return None.
+            let partition = self.partitions.get(self.current_partition_index)?;
+            match partition.request() {
+                Some(request) => {
+                    tracing::trace!(pkrange_id = ?partition.pkrange.id, "requesting data for partition");
+                    requests.push(request);
+                }
+                None => {
+                    tracing::trace!(pkrange_id = ?partition.pkrange.id, "partition exhausted, removing from list");
+                    self.current_partition_index += 1;
+                    self.current_pkrange_id = self
+                        .partitions
+                        .get(self.current_partition_index)
+                        .map(|p| p.pkrange.id.clone());
+                }
+            }
+        }
+        Some(requests)
+    }
+
+    pub fn provide_data(
+        &mut self,
+        pkrange_id: &str,
+        data: Vec<QueryResult>,
+        continuation: Option<String>,
+    ) -> crate::Result<()> {
+        match &self.current_pkrange_id {
+            Some(id) => {
+                if *id != pkrange_id {
+                    // The caller provided data for a different partition key range ID before draining the current items queue.
+                    return Err(ErrorKind::InternalError.with_message(format!(
+                        "provided data for partition key range ID: {}, but current partition is: {}",
+                        pkrange_id, id
+                    )));
+                }
+            }
+            None => {
+                return Err(ErrorKind::InternalError.with_message(format!(
+                    "provided data for partition key range ID: {}, but all partitions are exhausted",
+                    pkrange_id
+                )));
+            }
+        }
+
+        // Add the data to the items queue. There's no ordering to worry about, so we just append the items.
+        self.items.extend(data);
+
+        // Update the partition state with the continuation token
+        let partition = self
+            .partitions
+            .iter_mut()
+            .find(|p| p.pkrange.id == pkrange_id)
+            .ok_or_else(|| {
+                ErrorKind::UnknownPartitionKeyRange
+                    .with_message(format!("unknown partition key range ID: {pkrange_id}"))
+            })?;
+        partition.update_state(continuation);
+
+        Ok(())
+    }
+
+    pub fn produce_item(&mut self) -> crate::Result<PipelineNodeResult> {
+        let value = self.items.pop_front();
+        let terminated = self.items.is_empty()
+            && (self.current_partition_index == self.partitions.len() - 1)
+            && self.partitions[self.current_partition_index].done();
+        Ok(PipelineNodeResult { value, terminated })
+    }
+}


### PR DESCRIPTION
We use the "enum-dispatch" pattern (see https://crates.io/crates/enum_dispatch) to implement various producer "strategies" (NonStreaming, Streaming, Unordered). As we continue to expand the functionality of the pipeline, we'll need other strategies (ReadMany, Hybrid). The code is getting a little convoluted, since we do everything in the `match` arms. This PR refactors the strategies so they are each their own type (`UnorderedStrategy`, `StreamingStrategy`, etc.). The `ItemProducer` is just an enum that selects one of these concrete strategy types. There should be no functional differences, and the tests should be here as-is.

This is also _the same pattern_ we used before, just made a little more readable. Having said that, I put some more detail below on why enum-dispatch is used in Rust, since we have some new folks working in the codebase, but if you don't want to worry about it, you can stop here and just review the code :). 

### Why is enum-dispatch common in Rust?

Rust traits are most commonly used as trait bounds. For example:

```rust
pub trait Animal {
    fn speak(&self) -> &str;
}

struct Cat;

impl Animal for Cat {
    fn speak(&self) -> &str { "Meow" }
}

struct Dog;

impl Animal for Dog {
    fn speak(&self) -> &str { "Woof" }
}

fn speak_animal<A: Animal>(a: A) {
    a.speak()
}

fn main() {
    speak_animal(Cat)
    speak_animal(Dog)
}
```

Rust uses "monomorphisation" (the process of converting polymorphic functions/types into multiple monomorphic versions) here. There will be two different `speak_animal` functions in the final binary, one that calls `Cat::speak` and one that calls `Dog::speak` directly. This is different from .NET/Java, where you'd usually use dynamic dispatch, and a vtable to look up which of `Cat::speak` or `Dog::speak` to call at runtime based on the value of the type.

However, there are cases where you do want true polymorphism at runtime, for example, when you need to select a strategy at runtime. Dynamic dispatch can be quite costly though, particularly because it also hides a lot of useful information from the compiler. For internal APIs where we want polymorphism, we can achieve a similar result using Rust enums. This allows us to have multiple "implementations" of a single "interface", each with its own state and implementation code. Instead of dynamic dispatch, we effectively have a `match` (aka `switch`) statement that executes at runtime to select the implementation:

```rust
match self {
    Animal::Cat => "Meow",
    Animal::Dog => "Woof",
}
```

This can be heavily optimized by the compiler and usually ends up as a jump table, meaning it produces largely the same CPU instructions as the dynamic dispatch version (which would do an indirect call through a vtable pointer). It _also_ preserves all the necessary optimizations for the compiler to "see" in to the various optimizations. The compiler can inline implementations that are worth of inlining, and much more.

The result is a significant improvement in performance, as measured by the developers of the [`enum_dispatch`](https://docs.rs/enum_dispatch/latest/enum_dispatch/#the-benchmarks) crate (which provides a macro to automate this pattern).