### PR TITLE
Move query parsing down into Item Producers

### DIFF
--- a/azure_data_cosmos_engine/src/query/engine.rs
+++ b/azure_data_cosmos_engine/src/query/engine.rs
@@ -84,9 +84,12 @@ impl azure_data_cosmos::query::QueryPipeline for QueryPipelineAdapter {
         data: azure_data_cosmos::query::QueryResult,
     ) -> azure_core::Result<()> {
         tracing::debug!("providing data to pipeline");
-        let payload = self.0.result_shape().results_from_slice(data.result)?;
-        self.0
-            .provide_data(data.partition_key_range_id, payload, data.next_continuation)?;
+        // Pass the raw bytes directly to the pipeline
+        self.0.provide_data(
+            data.partition_key_range_id,
+            data.result,
+            data.next_continuation,
+        )?;
         Ok(())
     }
 }

--- a/azure_data_cosmos_engine/src/query/mod.rs
+++ b/azure_data_cosmos_engine/src/query/mod.rs
@@ -20,7 +20,7 @@ pub use engine::*;
 
 pub use pipeline::{QueryPipeline, SupportedFeatures, SUPPORTED_FEATURES};
 pub use plan::{DistinctType, QueryInfo, QueryPlan, QueryRange, SortOrder};
-pub use query_result::{QueryClauseItem, QueryResult};
+pub use query_result::{QueryClauseItem, QueryResult, QueryResultShape};
 
 /// Features that may be required by the Query Engine.
 ///

--- a/azure_data_cosmos_engine/src/query/pipeline.rs
+++ b/azure_data_cosmos_engine/src/query/pipeline.rs
@@ -12,7 +12,7 @@ use super::{
     node::{LimitPipelineNode, OffsetPipelineNode, PipelineNode, PipelineSlice},
     plan::{DistinctType, QueryRange},
     producer::ItemProducer,
-    PartitionKeyRange, PipelineResponse, QueryFeature, QueryPlan, QueryResult,
+    PartitionKeyRange, PipelineResponse, QueryFeature, QueryPlan,
 };
 
 /// Holds a list of [`QueryFeature`]s and a string representation suitable for being passed to the gateway when requesting a query plan.
@@ -109,7 +109,6 @@ pub struct QueryPipeline {
     query: String,
     pipeline: Vec<Box<dyn PipelineNode>>,
     producer: ItemProducer,
-    result_shape: QueryResultShape,
 
     // Indicates if the pipeline has been terminated early.
     terminated: bool,
@@ -131,8 +130,6 @@ impl QueryPipeline {
         let mut pkranges: Vec<PartitionKeyRange> = pkranges.into_iter().collect();
         get_overlapping_pk_ranges(&mut pkranges, &plan.query_ranges);
 
-        let mut result_shape = QueryResultShape::RawPayload;
-
         tracing::trace!(?query, ?plan, "creating query pipeline");
 
         // We don't support non-value aggregates, so make sure the query doesn't have any.
@@ -141,11 +138,21 @@ impl QueryPipeline {
                 .with_message("non-value aggregates are not supported"));
         }
 
+        if !plan.query_info.aggregates.is_empty() && !plan.query_info.order_by.is_empty() {
+            return Err(ErrorKind::UnsupportedQueryPlan
+                .with_message("queries with both ORDER BY and aggregates are not supported"));
+        }
+
         let producer = if plan.query_info.order_by.is_empty() {
             tracing::debug!("using unordered pipeline");
-            ItemProducer::unordered(pkranges)
+            // Determine the shape for unordered queries
+            let result_shape = if !plan.query_info.aggregates.is_empty() {
+                QueryResultShape::ValueAggregate
+            } else {
+                QueryResultShape::RawPayload
+            };
+            ItemProducer::unordered(pkranges, result_shape)
         } else {
-            result_shape = QueryResultShape::OrderBy;
             if plan.query_info.has_non_streaming_order_by {
                 tracing::debug!(?plan.query_info.order_by, "using non-streaming ORDER BY pipeline");
                 ItemProducer::non_streaming(pkranges, plan.query_info.order_by)
@@ -178,11 +185,6 @@ impl QueryPipeline {
         }
 
         if !plan.query_info.aggregates.is_empty() {
-            if result_shape != QueryResultShape::RawPayload {
-                return Err(ErrorKind::UnsupportedQueryPlan
-                    .with_message("cannot mix aggregates with ORDER BY"));
-            }
-            result_shape = QueryResultShape::ValueAggregate;
             pipeline.push(Box::new(AggregatePipelineNode::from_names(
                 plan.query_info.aggregates.clone(),
             )?));
@@ -217,17 +219,10 @@ impl QueryPipeline {
 
         Ok(Self {
             query,
-            result_shape,
             pipeline,
             producer,
             terminated: false,
         })
-    }
-
-    /// Retrieves the shape of the results produced by this pipeline.
-    /// The shape determines how the pipeline deserializes results from single-partition queries.
-    pub fn result_shape(&self) -> &QueryResultShape {
-        &self.result_shape
     }
 
     /// Retrieves the, possibly rewritten, query that this pipeline is executing.
@@ -248,7 +243,7 @@ impl QueryPipeline {
     pub fn provide_data(
         &mut self,
         pkrange_id: &str,
-        data: Vec<QueryResult>,
+        data: &[u8],
         continuation: Option<String>,
     ) -> crate::Result<()> {
         self.producer.provide_data(pkrange_id, data, continuation)

--- a/azure_data_cosmos_engine/src/query/pipeline.rs
+++ b/azure_data_cosmos_engine/src/query/pipeline.rs
@@ -284,8 +284,11 @@ impl QueryPipeline {
             }
 
             if let Some(item) = result.value {
-                // TODO: Handle scenarios where there is no payload (aggregates)
-                items.push(item.payload.unwrap());
+                let payload = item.into_payload().ok_or_else(|| {
+                    ErrorKind::InternalError
+                        .with_message("items yielded by the pipeline must have a payload")
+                })?;
+                items.push(payload);
             } else {
                 // The pipeline has finished for now, but we're not terminated yet.
                 break;

--- a/azure_data_cosmos_engine/src/query/producer/hybrid/fusion.rs
+++ b/azure_data_cosmos_engine/src/query/producer/hybrid/fusion.rs
@@ -1,0 +1,437 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::{BTreeSet, VecDeque};
+
+use serde::Deserialize;
+
+use crate::{
+    query::{
+        producer::hybrid::{
+            component_state::ComponentQueryState, models::ComponentQueryResult,
+            PaginationParameters,
+        },
+        QueryResult, SortOrder,
+    },
+    ErrorKind,
+};
+
+pub enum QueryResultCollector {
+    /// Collects results from a single component query.
+    /// There's no need to de-duplicate results in this case.
+    Singleton(Vec<ComponentQueryResult>),
+
+    /// Collects results from multiple component queries.
+    /// Results must be de-duplicated based on their RID.
+    Multiple(BTreeSet<ComponentQueryResult>),
+}
+
+impl QueryResultCollector {
+    pub fn singleton() -> Self {
+        QueryResultCollector::Singleton(Vec::new())
+    }
+
+    pub fn multiple() -> Self {
+        QueryResultCollector::Multiple(BTreeSet::new())
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            QueryResultCollector::Singleton(v) => v.len(),
+            QueryResultCollector::Multiple(s) => s.len(),
+        }
+    }
+
+    pub fn provide_data(&mut self, data: &[u8]) -> crate::Result<()> {
+        let result: DocumentResult<ComponentQueryResult> =
+            serde_json::from_slice(data).map_err(|e| {
+                ErrorKind::DeserializationError.with_message(format!(
+                    "failed to deserialize component query result: {}",
+                    e
+                ))
+            })?;
+
+        match self {
+            QueryResultCollector::Singleton(v) => v.extend(result.documents),
+            QueryResultCollector::Multiple(s) => {
+                for item in result.documents {
+                    #[cfg(debug_assertions)]
+                    let scores = item.payload.component_scores.clone();
+
+                    if let Some(old) = s.replace(item) {
+                        // Check that all the component scores are the same for duplicate items
+                        // We do have to include `#[cfg(debug_assertions)]` here, even though `debug_assert_eq!` exists.
+                        // `debug_assert_eq!` works using 'if cfg!(debug_assertions)', which means the code is still type-checked in release builds.
+                        // And it would error out because it can't find `scores`, which is only defined in debug builds.
+                        #[cfg(debug_assertions)]
+                        assert_eq!(
+                            old.payload.component_scores, scores,
+                            "mismatched component scores for duplicate hybrid search result"
+                        );
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn compute_final_results(
+        self,
+        pagination: PaginationParameters,
+        component_queries: &[ComponentQueryState],
+    ) -> crate::Result<VecDeque<QueryResult>> {
+        match self {
+            QueryResultCollector::Singleton(results) => Ok(pagination.paginate(results)),
+            QueryResultCollector::Multiple(results) => {
+                let scores = get_scores(component_queries, &results)?;
+                let ranks = scores.into_ranks();
+                let fused = ranks.into_fused_results(component_queries, results);
+                Ok(pagination.paginate(fused))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScoreTuple {
+    pub score: f64,
+    pub document_index: usize,
+}
+
+pub struct ScoreListBuilder {
+    scores: Vec<Vec<ScoreTuple>>,
+    component_sort_orders: Vec<SortOrder>,
+    document_count: usize,
+}
+
+impl ScoreListBuilder {
+    pub fn new(component_sort_orders: Vec<SortOrder>, document_count: usize) -> Self {
+        let lists = vec![Vec::with_capacity(document_count); component_sort_orders.len()];
+        Self {
+            scores: lists,
+            component_sort_orders,
+            document_count,
+        }
+    }
+
+    pub fn push_score(
+        &mut self,
+        component_index: usize,
+        score: f64,
+        document_index: usize,
+    ) -> crate::Result<()> {
+        if let Some(list) = self.scores.get_mut(component_index) {
+            list.push(ScoreTuple {
+                score,
+                document_index,
+            });
+            Ok(())
+        } else {
+            Err(ErrorKind::InternalError.with_message(format!(
+                "component index {} out of bounds (max {})",
+                component_index,
+                self.scores.len()
+            )))
+        }
+    }
+
+    pub fn build(mut self) -> ScoreList {
+        // Sort each component's scores according to its sort order
+        for (index, tuples) in self.scores.iter_mut().enumerate() {
+            let sort_order = self.component_sort_orders[index];
+            tuples.sort_by(|a, b| {
+                let ordering = a
+                    .score
+                    .partial_cmp(&b.score)
+                    .unwrap_or(std::cmp::Ordering::Equal);
+                match sort_order {
+                    SortOrder::Ascending => ordering,
+                    SortOrder::Descending => ordering.reverse(),
+                }
+            });
+        }
+        ScoreList {
+            scores: self.scores,
+            result_count: self.document_count,
+        }
+    }
+}
+
+pub struct ScoreList {
+    scores: Vec<Vec<ScoreTuple>>,
+    result_count: usize,
+}
+
+impl ScoreList {
+    /// Converts the scores into ranks for each component.
+    pub fn into_ranks(self) -> RankList {
+        let mut ranks = vec![vec![0; self.result_count]; self.scores.len()];
+
+        // The scores are in order, so all we have to do is assign ranks based on position.
+        // But, two identical scores should receive the same rank.
+        for (component_index, score_list) in self.scores.iter().enumerate() {
+            let mut current_rank = 1;
+            for i in 0..score_list.len() {
+                const ERROR_MARGIN: f64 = 1e-10;
+                if i > 0 && (score_list[i].score - score_list[i - 1].score).abs() > ERROR_MARGIN {
+                    current_rank += 1;
+                }
+                ranks[component_index][score_list[i].document_index] = current_rank;
+            }
+        }
+
+        RankList(ranks)
+    }
+}
+
+pub struct RankList(Vec<Vec<usize>>);
+
+impl RankList {
+    const RRF_CONSTANT: f64 = 60.0;
+
+    pub fn into_fused_results(
+        self,
+        components: &[ComponentQueryState],
+        results: impl IntoIterator<Item = ComponentQueryResult>,
+    ) -> Vec<ComponentQueryResult> {
+        debug_assert_eq!(self.0.len(), components.len());
+        let mut fused_results = Vec::new();
+
+        for (index, result) in results.into_iter().enumerate() {
+            let mut fused_score = 0.0;
+            for (component_index, rank_list) in self.0.iter().enumerate() {
+                let rank = rank_list[index] as f64;
+                let weight = components[component_index].weight;
+                fused_score += weight / (Self::RRF_CONSTANT + rank);
+            }
+            fused_results.push(RankFusionResult {
+                fused_score,
+                result,
+            })
+        }
+
+        fused_results.sort_by(|a, b| {
+            a.fused_score
+                .partial_cmp(&b.fused_score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .reverse()
+        });
+        fused_results.into_iter().map(|r| r.result).collect()
+    }
+}
+
+#[derive(Debug)]
+struct RankFusionResult {
+    fused_score: f64,
+    result: ComponentQueryResult,
+}
+
+impl PartialEq for RankFusionResult {
+    fn eq(&self, other: &Self) -> bool {
+        self.fused_score == other.fused_score
+    }
+}
+
+impl Eq for RankFusionResult {}
+
+impl PartialOrd for RankFusionResult {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RankFusionResult {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Only compare by fused score - stable sort will handle ties
+        other
+            .fused_score
+            .partial_cmp(&self.fused_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    }
+}
+
+fn get_scores(
+    component_queries: &[ComponentQueryState],
+    results: &BTreeSet<ComponentQueryResult>,
+) -> crate::Result<ScoreList> {
+    let sort_orders = component_queries
+        .iter()
+        .map(|cq| {
+            cq.query_info
+                .order_by
+                .get(0)
+                .copied()
+                .unwrap_or(SortOrder::Descending)
+        })
+        .collect();
+
+    let mut score_list = ScoreListBuilder::new(sort_orders, results.len());
+    for (index, result) in results.iter().enumerate() {
+        if result.payload.component_scores.len() != component_queries.len() {
+            return Err(ErrorKind::InternalError.with_message(format!(
+                "mismatched number of component scores in hybrid search result: expected {}, got {}",
+                component_queries.len(),
+                result.payload.component_scores.len()
+            )));
+        }
+
+        for (component_index, score) in result.payload.component_scores.iter().copied().enumerate()
+        {
+            score_list.push_score(component_index, score, index)?;
+        }
+    }
+
+    Ok(score_list.build())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use super::*;
+    use serde_json::value::RawValue;
+
+    // Helper functions
+    fn create_raw_payload(data: &str) -> Box<RawValue> {
+        RawValue::from_string(data.to_string()).unwrap()
+    }
+
+    fn create_test_result(rid: &str, scores: Vec<f64>) -> ComponentQueryResult {
+        ComponentQueryResult {
+            rid: rid.to_string(),
+            payload: crate::query::producer::hybrid::models::ComponentQueryPayload {
+                component_scores: scores,
+                user_payload: create_raw_payload(r#"{"test": "data"}"#),
+            },
+        }
+    }
+
+    fn create_mock_component_state(weight: f64) -> ComponentQueryState {
+        // Create a minimal component state for testing
+        // We only need the weight field for RRF calculations
+        let query_info = crate::query::QueryInfo::default();
+
+        ComponentQueryState::new(0, query_info, weight, &["partition1".to_string()])
+    }
+
+    // Priority 1: Score-to-rank conversion and RRF calculation
+    #[test]
+    fn test_score_list_into_ranks_with_ties() {
+        let mut builder = ScoreListBuilder::new(
+            vec![
+                SortOrder::Descending,
+                SortOrder::Ascending,
+                SortOrder::Ascending,
+            ],
+            5,
+        );
+
+        // Component 0: Descending with ties.
+        // Inverted order to test that the ranks are in document order.
+        builder.push_score(0, 100.0, 4).unwrap();
+        builder.push_score(0, 90.0, 3).unwrap();
+        builder.push_score(0, 90.0, 2).unwrap();
+        builder.push_score(0, 80.0, 1).unwrap();
+        builder.push_score(0, 70.0, 0).unwrap();
+
+        // Component 1: Ascending without ties.
+        builder.push_score(1, 10.0, 4).unwrap();
+        builder.push_score(1, 20.0, 3).unwrap();
+        builder.push_score(1, 30.0, 2).unwrap();
+        builder.push_score(1, 40.0, 1).unwrap();
+        builder.push_score(1, 50.0, 0).unwrap();
+
+        // Component 2: Ascending with ties.
+        builder.push_score(2, 5.0, 4).unwrap();
+        builder.push_score(2, 5.0, 3).unwrap();
+        builder.push_score(2, 15.0, 2).unwrap();
+        builder.push_score(2, 25.0, 1).unwrap();
+        builder.push_score(2, 35.0, 0).unwrap();
+
+        let score_list = builder.build();
+        let rank_list = score_list.into_ranks();
+        assert_eq!(
+            vec![
+                vec![4, 3, 2, 2, 1], // Component 0 ranks
+                vec![5, 4, 3, 2, 1], // Component 1 ranks
+                vec![4, 3, 2, 1, 1], // Component 2 ranks
+            ],
+            rank_list.0
+        );
+    }
+
+    #[test]
+    fn test_rrf_calculation() {
+        let components = vec![
+            create_mock_component_state(1.0),
+            create_mock_component_state(2.0),
+            create_mock_component_state(0.0),
+            create_mock_component_state(0.5),
+        ];
+
+        // Create rank lists for 4 components and 5 documents which demonstrate that each component's ranks are used correctly.
+        // The rankings here should result in an inverse ordering of the documents
+        let rank_list = RankList(vec![
+            vec![1, 2, 3, 4, 5], // Component 0 ranks
+            vec![5, 4, 3, 2, 1], // Component 1 ranks
+            vec![1, 1, 1, 1, 1], // Component 2 ranks (should not affect fused score)
+            vec![2, 2, 2, 2, 2], // Component 3 ranks
+        ]);
+
+        // Create the 5 results. The scores are irrelevant here because we've already computed artificial ranks
+        let results = vec![
+            create_test_result("doc1", vec![100.0, 80.0, 50.0, 70.0]),
+            create_test_result("doc2", vec![90.0, 85.0, 60.0, 65.0]),
+            create_test_result("doc3", vec![70.0, 70.0, 70.0, 60.0]),
+            create_test_result("doc4", vec![60.0, 75.0, 80.0, 55.0]),
+            create_test_result("doc5", vec![50.0, 90.0, 90.0, 50.0]),
+        ];
+
+        let fused = rank_list.into_fused_results(&components, results);
+
+        // Validate the ordering of fused results based on expected fused scores
+        assert_eq!(
+            vec!["doc5", "doc4", "doc3", "doc2", "doc1"],
+            fused.iter().map(|r| r.rid.as_str()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_score_tuple_ordering() {
+        // Create a score list with out-of-order scores and validate the final list is ordered by score
+        let mut builder = ScoreListBuilder::new(vec![SortOrder::Descending], 5);
+        builder.push_score(0, 50.0, 0).unwrap();
+        builder.push_score(0, 70.0, 1).unwrap();
+        builder.push_score(0, 30.0, 2).unwrap();
+        builder.push_score(0, 100.0, 3).unwrap();
+        builder.push_score(0, 90.0, 4).unwrap();
+
+        let score_list = builder.build();
+
+        assert_eq!(
+            vec![vec![
+                ScoreTuple {
+                    score: 100.0,
+                    document_index: 3
+                },
+                ScoreTuple {
+                    score: 90.0,
+                    document_index: 4
+                },
+                ScoreTuple {
+                    score: 70.0,
+                    document_index: 1
+                },
+                ScoreTuple {
+                    score: 50.0,
+                    document_index: 0
+                },
+                ScoreTuple {
+                    score: 30.0,
+                    document_index: 2
+                },
+            ]],
+            score_list.scores
+        )
+    }
+}

--- a/azure_data_cosmos_engine/src/query/producer/mod.rs
+++ b/azure_data_cosmos_engine/src/query/producer/mod.rs
@@ -144,7 +144,10 @@ mod tests {
     use serde_json::json;
 
     use crate::{
-        query::{query_result::QueryResultShape, PartitionKeyRange, QueryResult},
+        query::{
+            query_result::{FeedResponse, QueryResultShape},
+            PartitionKeyRange, QueryResult,
+        },
         ErrorKind,
     };
 
@@ -196,12 +199,9 @@ mod tests {
 
     /// Helper function to serialize QueryResult items back into the JSON format expected by the gateway
     fn serialize_query_results(results: &[QueryResult]) -> crate::Result<Vec<u8>> {
-        #[derive(Serialize)]
-        struct DocumentsWrapper<'a> {
-            #[serde(rename = "Documents")]
-            results: &'a [QueryResult],
-        }
-        let wrapper = DocumentsWrapper { results };
+        let wrapper = FeedResponse {
+            documents: results.to_vec(),
+        };
         let json = serde_json::to_vec(&wrapper).map_err(|e| {
             ErrorKind::InternalError
                 .with_message(format!("failed to serialize query results: {}", e))

--- a/azure_data_cosmos_engine/src/query/producer/non_streaming.rs
+++ b/azure_data_cosmos_engine/src/query/producer/non_streaming.rs
@@ -4,7 +4,10 @@
 use std::collections::BinaryHeap;
 
 use crate::{
-    query::{node::PipelineNodeResult, DataRequest, PartitionKeyRange, QueryResult, SortOrder},
+    query::{
+        node::PipelineNodeResult, query_result::QueryResultShape, DataRequest, PartitionKeyRange,
+        SortOrder,
+    },
     ErrorKind,
 };
 
@@ -50,11 +53,13 @@ impl NonStreamingStrategy {
     pub fn provide_data(
         &mut self,
         pkrange_id: &str,
-        data: Vec<QueryResult>,
+        data: &[u8],
         continuation: Option<String>,
     ) -> crate::Result<()> {
+        let parsed_data = QueryResultShape::OrderBy.results_from_slice(data)?;
+
         // Insert the items into the heap as we go, which will keep them sorted
-        for item in data {
+        for item in parsed_data {
             // We need to sort the items by the order by items, so we create a SortableResult.
             self.items
                 .push(SortableResult::new(self.sorting.clone(), item));

--- a/azure_data_cosmos_engine/src/query/producer/sorting.rs
+++ b/azure_data_cosmos_engine/src/query/producer/sorting.rs
@@ -115,7 +115,7 @@ mod tests {
     use std::cmp::Ordering;
 
     use crate::{
-        query::{producer::sorting::Sorting, QueryClauseItem, QueryResult},
+        query::{producer::sorting::Sorting, QueryClauseItem},
         ErrorKind,
     };
 

--- a/azure_data_cosmos_engine/src/query/producer/sorting.rs
+++ b/azure_data_cosmos_engine/src/query/producer/sorting.rs
@@ -26,9 +26,12 @@ impl PartialOrd for SortableResult {
 
 impl Ord for SortableResult {
     fn cmp(&self, other: &Self) -> Ordering {
+        let (left_order_by_items, _) = self.1.as_order_by().expect("should have order by items");
+        let (right_order_by_items, _) = other.1.as_order_by().expect("should have order by items");
+
         // Unless the gateway provides invalid data, this shouldn't fail.
         self.0
-            .compare(Some(&self.1.order_by_items), Some(&other.1.order_by_items))
+            .compare(Some(&left_order_by_items), Some(&right_order_by_items))
             .expect("Sorting should not fail")
     }
 }
@@ -118,108 +121,77 @@ mod tests {
 
     #[test]
     pub fn compare_query_results_different() {
-        let left = QueryResult {
-            order_by_items: vec![
-                QueryClauseItem::from_value(serde_json::json!(1)),
-                QueryClauseItem::from_value(serde_json::json!("zzzz")),
-            ],
-            ..Default::default()
-        };
-        let right = QueryResult {
-            order_by_items: vec![
-                QueryClauseItem::from_value(serde_json::json!(1)),
-                QueryClauseItem::from_value(serde_json::json!("yyyy")),
-            ],
-            ..Default::default()
-        };
+        let left = vec![
+            QueryClauseItem::from_value(serde_json::json!(1)),
+            QueryClauseItem::from_value(serde_json::json!("zzzz")),
+        ];
+        let right = vec![
+            QueryClauseItem::from_value(serde_json::json!(1)),
+            QueryClauseItem::from_value(serde_json::json!("yyyy")),
+        ];
         let sorting = Sorting::new(vec![
             crate::query::SortOrder::Ascending,
             crate::query::SortOrder::Descending,
         ]);
         assert_eq!(
             Ordering::Greater,
-            sorting
-                .compare(Some(&left.order_by_items), Some(&right.order_by_items))
-                .unwrap()
+            sorting.compare(Some(&left), Some(&right)).unwrap()
         );
     }
 
     #[test]
     pub fn compare_query_results_identical() {
-        let left = QueryResult {
-            order_by_items: vec![
-                QueryClauseItem::from_value(serde_json::json!(1)),
-                QueryClauseItem::from_value(serde_json::json!("zzzz")),
-            ],
-            ..Default::default()
-        };
-        let right = QueryResult {
-            order_by_items: vec![
-                QueryClauseItem::from_value(serde_json::json!(1)),
-                QueryClauseItem::from_value(serde_json::json!("zzzz")),
-            ],
-            ..Default::default()
-        };
+        let left = vec![
+            QueryClauseItem::from_value(serde_json::json!(1)),
+            QueryClauseItem::from_value(serde_json::json!("zzzz")),
+        ];
+        let right = vec![
+            QueryClauseItem::from_value(serde_json::json!(1)),
+            QueryClauseItem::from_value(serde_json::json!("zzzz")),
+        ];
         let sorting = Sorting::new(vec![
             crate::query::SortOrder::Ascending,
             crate::query::SortOrder::Descending,
         ]);
         assert_eq!(
             Ordering::Equal,
-            sorting
-                .compare(Some(&left.order_by_items), Some(&right.order_by_items))
-                .unwrap()
+            sorting.compare(Some(&left), Some(&right)).unwrap()
         );
     }
 
     #[test]
     pub fn compare_with_empty() {
-        let non_empty = QueryResult {
-            order_by_items: vec![
-                QueryClauseItem::from_value(serde_json::json!(1)),
-                QueryClauseItem::from_value(serde_json::json!("zzzz")),
-            ],
-            ..Default::default()
-        };
+        let non_empty = vec![
+            QueryClauseItem::from_value(serde_json::json!(1)),
+            QueryClauseItem::from_value(serde_json::json!("zzzz")),
+        ];
         let sorting = Sorting::new(vec![
             crate::query::SortOrder::Ascending,
             crate::query::SortOrder::Descending,
         ]);
         assert_eq!(
             Ordering::Greater,
-            sorting
-                .compare(None, Some(&non_empty.order_by_items))
-                .unwrap()
+            sorting.compare(None, Some(&non_empty)).unwrap()
         );
         assert_eq!(
             Ordering::Less,
-            sorting
-                .compare(Some(&non_empty.order_by_items), None)
-                .unwrap()
+            sorting.compare(Some(&non_empty), None).unwrap()
         );
         assert_eq!(Ordering::Equal, sorting.compare(None, None).unwrap());
     }
 
     #[test]
     pub fn compare_query_results_inconsistent() {
-        let left = QueryResult {
-            order_by_items: vec![QueryClauseItem::from_value(serde_json::json!(1))],
-            ..Default::default()
-        };
-        let right = QueryResult {
-            order_by_items: vec![
-                QueryClauseItem::from_value(serde_json::json!(1)),
-                QueryClauseItem::from_value(serde_json::json!("zzzz")),
-            ],
-            ..Default::default()
-        };
+        let left = vec![QueryClauseItem::from_value(serde_json::json!(1))];
+        let right = vec![
+            QueryClauseItem::from_value(serde_json::json!(1)),
+            QueryClauseItem::from_value(serde_json::json!("zzzz")),
+        ];
         let sorting = Sorting::new(vec![
             crate::query::SortOrder::Ascending,
             crate::query::SortOrder::Descending,
         ]);
-        let err = sorting
-            .compare(Some(&left.order_by_items), Some(&right.order_by_items))
-            .unwrap_err();
+        let err = sorting.compare(Some(&left), Some(&right)).unwrap_err();
         assert_eq!(ErrorKind::InvalidGatewayResponse, err.kind());
     }
 }

--- a/azure_data_cosmos_engine/src/query/producer/streaming.rs
+++ b/azure_data_cosmos_engine/src/query/producer/streaming.rs
@@ -126,10 +126,14 @@ impl StreamingStrategy {
                     current_match = Some((i, buffer.front()));
                 }
                 Some((current_index, current_item)) => {
-                    match self.sorting.compare(
-                        current_item.map(|r| r.order_by_items.as_slice()),
-                        buffer.front().map(|r| r.order_by_items.as_slice()),
-                    )? {
+                    let current_order_by_items =
+                        current_item.and_then(|r| r.as_order_by()).map(|(i, _)| i);
+                    let new_order_by_items =
+                        buffer.front().and_then(|r| r.as_order_by()).map(|(i, _)| i);
+                    match self
+                        .sorting
+                        .compare(current_order_by_items, new_order_by_items)?
+                    {
                         Ordering::Greater => {
                             // The current item sorts higher than the new item, so we keep the current match.
                             continue;

--- a/azure_data_cosmos_engine/tests/mock_engine/mod.rs
+++ b/azure_data_cosmos_engine/tests/mock_engine/mod.rs
@@ -11,7 +11,7 @@
 use std::{collections::BTreeMap, fmt::Debug};
 
 use azure_data_cosmos_engine::query::{
-    DataRequest, PartitionKeyRange, QueryPipeline, QueryPlan, QueryResult, QueryResultShape,
+    DataRequest, PartitionKeyRange, QueryPipeline, QueryPlan, QueryResult,
 };
 use serde::Serialize;
 use tracing_subscriber::EnvFilter;
@@ -20,7 +20,6 @@ pub struct Engine {
     container: Container,
     pipeline: QueryPipeline,
     request_page_size: usize,
-    result_shape: QueryResultShape,
 }
 
 impl Engine {
@@ -46,7 +45,6 @@ impl Engine {
         query: &str,
         plan: QueryPlan,
         request_page_size: usize,
-        result_shape: QueryResultShape,
     ) -> Result<Self, azure_data_cosmos_engine::Error> {
         // Divide the EPK space evenly among the partitions we have
         const MAX_EPK: u32 = 0xFFFF_FFFF;
@@ -78,7 +76,6 @@ impl Engine {
             container,
             pipeline,
             request_page_size,
-            result_shape,
         })
     }
 

--- a/azure_data_cosmos_engine/tests/mock_engine/mod.rs
+++ b/azure_data_cosmos_engine/tests/mock_engine/mod.rs
@@ -114,7 +114,7 @@ impl Engine {
                     self.request_page_size,
                 );
                 // Serialize the QueryResult items to bytes
-                let json_bytes = serialize_query_results(&page.items)?;
+                let json_bytes = serialize_query_results(page.items)?;
                 self.pipeline
                     .provide_data(&request.pkrange_id, &json_bytes, page.continuation)?;
             }
@@ -126,12 +126,13 @@ impl Engine {
 
 /// Helper function to serialize QueryResult items back into the JSON format expected by the gateway
 fn serialize_query_results(
-    results: &[QueryResult],
+    results: Vec<QueryResult>,
 ) -> Result<Vec<u8>, azure_data_cosmos_engine::Error> {
+    // Note: This must be defined here because the one in `azure_data_cosmos_engine` is private.
     #[derive(Serialize)]
-    struct DocumentResults<'a, T> {
+    struct DocumentResults {
         #[serde(rename = "Documents")]
-        documents: &'a [T],
+        documents: Vec<QueryResult>,
     }
     serde_json::to_vec(&DocumentResults { documents: results }).map_err(|e| {
         azure_data_cosmos_engine::ErrorKind::InternalError

--- a/azure_data_cosmos_engine/tests/pipeline_basic_queries.rs
+++ b/azure_data_cosmos_engine/tests/pipeline_basic_queries.rs
@@ -36,10 +36,7 @@ impl Item {
 impl From<Item> for QueryResult {
     fn from(item: Item) -> Self {
         let value = serde_json::value::to_raw_value(&item.title).unwrap();
-        QueryResult {
-            payload: Some(value),
-            ..Default::default()
-        }
+        QueryResult::RawPayload(value)
     }
 }
 

--- a/azure_data_cosmos_engine/tests/pipeline_basic_queries.rs
+++ b/azure_data_cosmos_engine/tests/pipeline_basic_queries.rs
@@ -3,7 +3,7 @@
 
 use std::vec;
 
-use azure_data_cosmos_engine::query::{DataRequest, QueryPlan, QueryResult};
+use azure_data_cosmos_engine::query::{DataRequest, QueryPlan, QueryResult, QueryResultShape};
 use pretty_assertions::assert_eq;
 
 use mock_engine::{Container, Engine};
@@ -79,6 +79,7 @@ pub fn unordered_query() -> Result<(), Box<dyn std::error::Error>> {
             query_ranges: Vec::new(),
         },
         3,
+        QueryResultShape::RawPayload,
     )?;
 
     // Execute the query, and flatten the response down to just the title for easier comparison.

--- a/azure_data_cosmos_engine/tests/pipeline_basic_queries.rs
+++ b/azure_data_cosmos_engine/tests/pipeline_basic_queries.rs
@@ -3,7 +3,7 @@
 
 use std::vec;
 
-use azure_data_cosmos_engine::query::{DataRequest, QueryPlan, QueryResult, QueryResultShape};
+use azure_data_cosmos_engine::query::{DataRequest, QueryPlan, QueryResult};
 use pretty_assertions::assert_eq;
 
 use mock_engine::{Container, Engine};
@@ -76,7 +76,6 @@ pub fn unordered_query() -> Result<(), Box<dyn std::error::Error>> {
             query_ranges: Vec::new(),
         },
         3,
-        QueryResultShape::RawPayload,
     )?;
 
     // Execute the query, and flatten the response down to just the title for easier comparison.

--- a/azure_data_cosmos_engine/tests/pipeline_limiting.rs
+++ b/azure_data_cosmos_engine/tests/pipeline_limiting.rs
@@ -4,7 +4,7 @@
 use std::vec;
 
 use azure_data_cosmos_engine::query::{
-    DataRequest, QueryClauseItem, QueryInfo, QueryPlan, QueryResult, QueryResultShape, SortOrder,
+    DataRequest, QueryClauseItem, QueryInfo, QueryPlan, QueryResult, SortOrder,
 };
 use pretty_assertions::assert_eq;
 
@@ -95,7 +95,6 @@ pub fn top() -> Result<(), Box<dyn std::error::Error>> {
             query_ranges: Vec::new(),
         },
         3,
-        QueryResultShape::OrderBy,
     )?;
 
     // Execute the query, and flatten the response down to just the title for easier comparison.
@@ -171,7 +170,6 @@ pub fn offset_limit() -> Result<(), Box<dyn std::error::Error>> {
             query_ranges: Vec::new(),
         },
         2, // Really force the engine to make lots of requests.
-        QueryResultShape::OrderBy,
     )?;
 
     // Execute the query, and flatten the response down to just the title for easier comparison.

--- a/azure_data_cosmos_engine/tests/pipeline_limiting.rs
+++ b/azure_data_cosmos_engine/tests/pipeline_limiting.rs
@@ -51,10 +51,9 @@ impl From<Item> for QueryResult {
             serde_json::Number::from(item.sort0),
         ));
         let sort1 = QueryClauseItem::from_value(serde_json::Value::String(item.sort1.clone()));
-        QueryResult {
+        QueryResult::OrderBy {
             order_by_items: vec![sort0, sort1],
-            payload: Some(raw),
-            ..Default::default()
+            payload: raw,
         }
     }
 }

--- a/azure_data_cosmos_engine/tests/pipeline_limiting.rs
+++ b/azure_data_cosmos_engine/tests/pipeline_limiting.rs
@@ -4,7 +4,7 @@
 use std::vec;
 
 use azure_data_cosmos_engine::query::{
-    DataRequest, QueryClauseItem, QueryInfo, QueryPlan, QueryResult, SortOrder,
+    DataRequest, QueryClauseItem, QueryInfo, QueryPlan, QueryResult, QueryResultShape, SortOrder,
 };
 use pretty_assertions::assert_eq;
 
@@ -96,6 +96,7 @@ pub fn top() -> Result<(), Box<dyn std::error::Error>> {
             query_ranges: Vec::new(),
         },
         3,
+        QueryResultShape::OrderBy,
     )?;
 
     // Execute the query, and flatten the response down to just the title for easier comparison.
@@ -171,6 +172,7 @@ pub fn offset_limit() -> Result<(), Box<dyn std::error::Error>> {
             query_ranges: Vec::new(),
         },
         2, // Really force the engine to make lots of requests.
+        QueryResultShape::OrderBy,
     )?;
 
     // Execute the query, and flatten the response down to just the title for easier comparison.

--- a/azure_data_cosmos_engine/tests/pipeline_range_filtering.rs
+++ b/azure_data_cosmos_engine/tests/pipeline_range_filtering.rs
@@ -3,9 +3,7 @@
 
 use std::vec;
 
-use azure_data_cosmos_engine::query::{
-    DataRequest, QueryInfo, QueryPlan, QueryRange, QueryResult, QueryResultShape,
-};
+use azure_data_cosmos_engine::query::{DataRequest, QueryInfo, QueryPlan, QueryRange, QueryResult};
 use pretty_assertions::assert_eq;
 
 use mock_engine::{Container, Engine};
@@ -94,7 +92,6 @@ pub fn pkranges_filtered_by_query_ranges() -> Result<(), Box<dyn std::error::Err
         "SELECT * FROM c WHERE c.partitionKey = 'specific_value'",
         query_plan,
         3,
-        QueryResultShape::RawPayload,
     )?;
 
     let results = engine.execute()?;
@@ -190,7 +187,6 @@ pub fn pkranges_filtered_by_overlapping_query_ranges() -> Result<(), Box<dyn std
         "SELECT * FROM c WHERE c.someField BETWEEN 'value1' AND 'value2'",
         query_plan,
         3,
-        QueryResultShape::RawPayload,
     )?;
 
     let results = engine.execute()?;
@@ -284,13 +280,7 @@ pub fn pkranges_filtered_by_all_partitions_query_range() -> Result<(), Box<dyn s
         }],
     };
 
-    let engine = Engine::new(
-        container,
-        "SELECT * FROM c",
-        query_plan,
-        3,
-        QueryResultShape::RawPayload,
-    )?;
+    let engine = Engine::new(container, "SELECT * FROM c", query_plan, 3)?;
 
     let results = engine.execute()?;
 
@@ -384,13 +374,7 @@ pub fn pkranges_no_query_ranges_queries_all_partitions() -> Result<(), Box<dyn s
         query_ranges: Vec::new(),
     };
 
-    let engine = Engine::new(
-        container,
-        "SELECT * FROM c",
-        query_plan,
-        3,
-        QueryResultShape::RawPayload,
-    )?;
+    let engine = Engine::new(container, "SELECT * FROM c", query_plan, 3)?;
 
     let results = engine.execute()?;
 

--- a/azure_data_cosmos_engine/tests/pipeline_streaming_order_by.rs
+++ b/azure_data_cosmos_engine/tests/pipeline_streaming_order_by.rs
@@ -51,10 +51,9 @@ impl From<Item> for QueryResult {
             serde_json::Number::from(item.sort0),
         ));
         let sort1 = QueryClauseItem::from_value(serde_json::Value::String(item.sort1.clone()));
-        QueryResult {
+        QueryResult::OrderBy {
             order_by_items: vec![sort0, sort1],
-            payload: Some(raw),
-            ..Default::default()
+            payload: raw,
         }
     }
 }

--- a/azure_data_cosmos_engine/tests/pipeline_streaming_order_by.rs
+++ b/azure_data_cosmos_engine/tests/pipeline_streaming_order_by.rs
@@ -4,7 +4,7 @@
 use std::vec;
 
 use azure_data_cosmos_engine::query::{
-    DataRequest, QueryClauseItem, QueryInfo, QueryPlan, QueryResult, SortOrder,
+    DataRequest, QueryClauseItem, QueryInfo, QueryPlan, QueryResult, QueryResultShape, SortOrder,
 };
 use pretty_assertions::assert_eq;
 
@@ -97,6 +97,7 @@ pub fn streaming_order_by() -> Result<(), Box<dyn std::error::Error>> {
             query_ranges: Vec::new(),
         },
         3,
+        QueryResultShape::OrderBy,
     )?;
 
     // Execute the query, and flatten the response down to just the title for easier comparison.

--- a/azure_data_cosmos_engine/tests/pipeline_streaming_order_by.rs
+++ b/azure_data_cosmos_engine/tests/pipeline_streaming_order_by.rs
@@ -4,7 +4,7 @@
 use std::vec;
 
 use azure_data_cosmos_engine::query::{
-    DataRequest, QueryClauseItem, QueryInfo, QueryPlan, QueryResult, QueryResultShape, SortOrder,
+    DataRequest, QueryClauseItem, QueryInfo, QueryPlan, QueryResult, SortOrder,
 };
 use pretty_assertions::assert_eq;
 
@@ -96,7 +96,6 @@ pub fn streaming_order_by() -> Result<(), Box<dyn std::error::Error>> {
             query_ranges: Vec::new(),
         },
         3,
-        QueryResultShape::OrderBy,
     )?;
 
     // Execute the query, and flatten the response down to just the title for easier comparison.

--- a/cosmoscx/src/pipeline.rs
+++ b/cosmoscx/src/pipeline.rs
@@ -222,12 +222,8 @@ pub extern "C" fn cosmoscx_v0_query_pipeline_provide_data<'a>(
             }
         };
 
-        let query_results = pipeline
-            .result_shape()
-            .results_from_slice(data.as_bytes())?;
-
-        // And insert it!
-        pipeline.provide_data(pkrange_id, query_results, continuation)
+        // Pass the raw bytes directly to the pipeline
+        pipeline.provide_data(pkrange_id, data.as_bytes(), continuation)
     }
 
     inner(pipeline, pkrange_id, data, continuation).into()

--- a/python/src/pipeline.rs
+++ b/python/src/pipeline.rs
@@ -63,10 +63,8 @@ impl NativeQueryPipeline {
         let continuation = continuation
             .map(|s| s.to_str().map(|s| s.to_string()))
             .transpose()?;
-        let data = pipeline
-            .result_shape()
-            .results_from_slice(data.as_bytes())?;
-        pipeline.provide_data(pkrange_id, data, continuation)?;
+        // Pass the raw bytes directly to the pipeline
+        pipeline.provide_data(pkrange_id, data.as_bytes(), continuation)?;
         Ok(())
     }
 }


### PR DESCRIPTION
An Item Producer always knows what "shape" to expect a query result to be in, so this PR moves parsing down to that layer. Previously, the pipeline expected pre-parsed `QueryResult` values, but that's become untenable as we have several different result shapes to content with:

1. "Raw Payloads" for unordered queries, and presumably ReadMany (cc @tvaron3 @simorenoh)
2. "Order By" payloads with `orderByItems` extracted by the gateway for streaming/non-streaming ordered queries
3. "Aggregate" payloads for `SELECT VALUE [aggregate](...)` queries
4. Hybrid-related queries (Global Statistics, Component Queries) coming soon

Given that, I decided to make a few refactorings to make things a little easier:

1. Push parsing down to the `ItemProducer` (so we just pass `&[u8]` representing the raw JSON response from the server down)
2. Change `QueryResult` to an enum. Previously, it was trying to be a single struct that could hold the union of all possible results, but that gets messy for things like per-partition aggregate results which don't really have a "payload". So instead, there are multiple variants and as long as nodes receive the appropriate kind of result and the final result emitted by the pipeline has a payload, everybody is happy.