### PR TITLE
update versions and changelog for 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Release History
 
-## 0.2.0 (Unreleased)
+## 0.3.0 (2025-11-20)
 
 ### Features Added
 
-### Breaking Changes
+* Support for Hybrid and Full-Text queries - [PR 51](https://github.com/Azure/azure-cosmos-client-engine/pull/51)
 
-### Bugs Fixed
+## 0.2.0 (2025-11-04)
 
-### Other Change
+### Features Added
+
+* Optimized partition key range selection logic to filter out ranges not relevant to the query. - [PR 47](https://github.com/Azure/azure-cosmos-client-engine/pull/47)
 
 ## 0.1.0 (2025-10-22)
 
@@ -16,12 +18,6 @@
 
 * Added ability to get effective partition key string from a partition key value. - [PR 39](https://github.com/Azure/azure-cosmos-client-engine/pull/39)
 * Added support for SELECT VALUE queries that include aggregate functions. - [PR 43](https://github.com/Azure/azure-cosmos-client-engine/pull/43)
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Change
 
 ## 0.0.5 (2025-02-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 * Support for Hybrid and Full-Text queries - [PR 51](https://github.com/Azure/azure-cosmos-client-engine/pull/51)
+* Update APIs to support providing multiple results to the pipeline at once - [PR 51](https://github.com/Azure/azure-cosmos-client-engine/pull/51)
 
 ## 0.2.0 (2025-11-04)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "azure_cosmoscx_python"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "azure_data_cosmos_engine",
  "pyo3",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "azure_data_cosmos_engine"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "azure_core",
  "azure_data_cosmos",
@@ -253,7 +253,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cosmoscx"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "azure_data_cosmos_engine",
  "serde",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "query-tests"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "azure_core",
  "azure_data_cosmos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["azure_data_cosmos_engine", "azure_data_cosmos_engine/query-tests", "cosmoscx", "python"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 
 [workspace.dependencies]
 azure_data_cosmos_engine = { path = "azure_data_cosmos_engine" }


### PR DESCRIPTION
This PR cleans up the CHANGELOG a bit (since it's manually-managed, I neglected to update 0.2.0) and preps for a 0.3.0 release today.